### PR TITLE
Fix SVG background aspect ratios to prevent stretching

### DIFF
--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -12,7 +12,7 @@ export default function ForgotPasswordPage() {
       {/* Left Side - Value Proposition */}
       <div className="hidden lg:flex lg:w-1/2 xl:w-3/5 bg-gradient-to-br from-[#F5F5FF] to-[#FFF5F5] relative overflow-hidden">
         {/* Background Pattern */}
-        <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="none">
+        <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="xMidYMid slice">
           <defs>
             <pattern id="dots-forgot-left" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
               <circle cx="2" cy="2" r="1" fill="rgba(0,0,0,0.02)" />

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -12,7 +12,7 @@ export default function ResetPasswordPage() {
       {/* Left Side - Value Proposition */}
       <div className="hidden lg:flex lg:w-1/2 xl:w-3/5 bg-gradient-to-br from-[#F5F5FF] to-[#FFF5F5] relative overflow-hidden">
         {/* Background Pattern */}
-        <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="none">
+        <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="xMidYMid slice">
           <defs>
             <pattern id="dots-reset-left" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
               <circle cx="2" cy="2" r="1" fill="rgba(0,0,0,0.02)" />

--- a/app/(auth)/signin/page.tsx
+++ b/app/(auth)/signin/page.tsx
@@ -12,7 +12,7 @@ export default function SignInPage() {
       {/* Left Side - Value Proposition */}
       <div className="hidden lg:flex lg:w-1/2 xl:w-3/5 bg-gradient-to-br from-[#F5F5FF] to-[#FFF5F5] relative overflow-hidden">
         {/* Background Pattern */}
-        <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="none">
+        <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="xMidYMid slice">
           <defs>
             <pattern id="dots-signin-left" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
               <circle cx="2" cy="2" r="1" fill="rgba(0,0,0,0.02)" />

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -12,7 +12,7 @@ export default function SignUpPage() {
       {/* Left Side - Value Proposition */}
       <div className="hidden lg:flex lg:w-1/2 xl:w-3/5 bg-gradient-to-br from-[#F5F5FF] to-[#FFF5F5] relative overflow-hidden">
         {/* Background Pattern */}
-        <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="none">
+        <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="xMidYMid slice">
           <defs>
             <pattern id="dots-signup-left" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
               <circle cx="2" cy="2" r="1" fill="rgba(0,0,0,0.02)" />

--- a/components/landing/professional-hero.tsx
+++ b/components/landing/professional-hero.tsx
@@ -44,7 +44,7 @@ export default function ProfessionalHero({ isAuthenticated }: ProfessionalHeroPr
       className="relative min-h-screen overflow-hidden bg-gradient-to-br from-[#F5F5FF] to-[#FFF5F5] pattern-mesh"
     >
       {/* Background Pattern - matching auth pages */}
-      <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="none">
+      <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="xMidYMid slice">
         <defs>
           <pattern id="dots-hero" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
             <circle cx="2" cy="2" r="1" fill="rgba(0,0,0,0.02)" />

--- a/components/learning/review-interface.tsx
+++ b/components/learning/review-interface.tsx
@@ -225,7 +225,7 @@ export default function ReviewInterface({ sessionId }: { sessionId: string }) {
   return (
     <div className="min-h-screen bg-gradient-to-br from-[#F5F5FF] to-[#FFF5F5] relative overflow-hidden">
       {/* Background Pattern */}
-      <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="none">
+      <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="xMidYMid slice">
         <defs>
           <pattern id="dots-review" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
             <circle cx="2" cy="2" r="1" fill="rgba(0,0,0,0.02)" />

--- a/components/ui/page-loader.tsx
+++ b/components/ui/page-loader.tsx
@@ -101,7 +101,7 @@ export function EnhancedLoader({
           transition={{ duration: 0.8, ease: "easeOut" }}
         >
           {/* Background Pattern */}
-          <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="none">
+          <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 1000" preserveAspectRatio="xMidYMid slice">
             <defs>
               <pattern id="dots-loader" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
                 <circle cx="2" cy="2" r="1" fill="rgba(0,0,0,0.02)" />


### PR DESCRIPTION
## Summary
- Fixed SVG background animations across all auth pages and components
- Changed `preserveAspectRatio` from `none` to `xMidYMid slice` to maintain 1:1 aspect ratio
- Prevents background distortion and stretching issues

## Changes Made
- ✅ Fixed signin page background SVG
- ✅ Fixed signup page background SVG  
- ✅ Fixed forgot-password page background SVG
- ✅ Fixed reset-password page background SVG
- ✅ Fixed homepage hero component background SVG
- ✅ Fixed page loader component background SVG
- ✅ Fixed review interface component background SVG

## Test Plan
- [x] Build passes successfully (`npm run build`)
- [x] Lint checks pass
- [x] Visual inspection of all affected pages shows proper aspect ratio
- [ ] Manual testing on different viewport sizes

## Before/After
**Before:** SVG backgrounds would stretch and distort with `preserveAspectRatio="none"`
**After:** SVG backgrounds maintain 1:1 aspect ratio with `preserveAspectRatio="xMidYMid slice"`, properly cropping to fit viewport

🤖 Generated with [Claude Code](https://claude.ai/code)