### PR TITLE
Remove duplicate install prompt interface

### DIFF
--- a/app/sw-register.ts
+++ b/app/sw-register.ts
@@ -41,11 +41,6 @@ interface BeforeInstallPromptEvent extends Event {
   userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
 }
 
-interface BeforeInstallPromptEvent extends Event {
-  prompt: () => Promise<void>
-  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
-}
-
 export function setupInstallPrompt() {
   if (typeof window === 'undefined') return
 


### PR DESCRIPTION
## Summary
- remove redundant BeforeInstallPromptEvent declaration in service worker registration

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68995a016a50832aae0f49a826ca5aef