### PR TITLE
Add typecheck and e2e test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,19 +144,17 @@ npm run typecheck       # TypeScript checking
 
 ### Database
 ```bash
-npm run db:start        # Start local Supabase
-npm run db:stop         # Stop local Supabase
 npm run db:reset        # Reset & apply migrations
 npm run db:types        # Generate TypeScript types
-npm run db:push         # Deploy migrations to production
 ```
 
 ### Testing
 ```bash
-npm run test            # Run unit tests
+npm run test            # Run unit tests once
+npm run test:watch      # Run unit tests in watch mode
 npm run test:ui         # Interactive test UI
-npm run test:e2e        # End-to-end tests
 npm run test:coverage   # Coverage report
+npm run test:e2e        # End-to-end tests
 ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@next/bundle-analyzer": "^15.4.6",
+        "@playwright/test": "^1.54.2",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20.17.57",
         "@types/react": "^19",
@@ -1927,9 +1928,8 @@
       "version": "1.54.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
       "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "playwright": "1.54.2"
       },
@@ -8995,9 +8995,8 @@
       "version": "1.54.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
       "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.54.2"
       },
@@ -9015,9 +9014,8 @@
       "version": "1.54.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
       "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -9029,13 +9027,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,12 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test --config=playwright-background.config.js",
     "db:reset": "supabase db reset",
     "db:types": "supabase gen types --local > types/supabase.ts",
     "prepare": "husky"
@@ -64,6 +69,7 @@
     "prettier": "^3.5.3",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "vitest": "^3.1.4"
+    "vitest": "^3.1.4",
+    "@playwright/test": "^1.54.2"
   }
 }

--- a/playwright-background.config.js
+++ b/playwright-background.config.js
@@ -2,6 +2,9 @@
 // This configuration helps prevent browser windows from taking over your screen
 
 module.exports = {
+  // Directory containing end-to-end tests
+  testDir: 'e2e',
+
   // Run in headless mode by default
   use: {
     headless: true, // Set to false only when you need to debug visually


### PR DESCRIPTION
## Summary
- add TypeScript, unit, coverage, watch, and Playwright test scripts
- document available test commands and drop non-existent database scripts
- scope Playwright to an `e2e` directory

## Testing
- `npm run lint`
- `npm run typecheck` (fails: Transition type errors and Supabase client type mismatch)
- `npm test`
- `npm run test:e2e` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_689959f582f0832ab904c496ebc506e5