### PR TITLE
fix: restrict Vitest to unit tests (#71)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     passWithNoTests: true,
+    include: ['__tests__/**/*.test.ts'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- limit Vitest to unit test directory so Playwright specs aren't executed by mistake

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aacc33194832a9d93368185337ade